### PR TITLE
Search UI enhancements: modal UX, suggestions, skeleton, header styling

### DIFF
--- a/frontend/app/components/HeaderClient.tsx
+++ b/frontend/app/components/HeaderClient.tsx
@@ -202,10 +202,14 @@ export default function HeaderClient({
         className={`fixed left-0 right-0 top-0 z-50 h-24 flex items-center transition-all duration-700 ease-out ${
           isSticky 
             ? 'bg-[#553920]/85 shadow-lg backdrop-blur-[2px]' 
-            : `bg-transparent lg:bg-transparent sm:bg-transparent bg-[#ff6b00]/90 shadow-none backdrop-blur-0 border-t-2 border-b-2 border-dashed ${
-                isMegaOpen 
-                  ? 'border-[#ff8c42]/12 backdrop-blur-lg' 
-                  : 'border-[#ff8c42]/60'
+            : `bg-transparent lg:bg-transparent sm:bg-transparent bg-[#ff6b00]/90 shadow-none backdrop-blur-0 ${
+                !isSearchOpen
+                  ? `border-t-2 border-b-2 border-dashed ${
+                      isMegaOpen 
+                        ? 'border-[#ff8c42]/12 backdrop-blur-lg' 
+                        : 'border-[#ff8c42]/60'
+                    }`
+                  : ''
               }`
         } ${(isMegaOpen || isSearchOpen) ? 'bg-black/50 backdrop-blur-lg' : ''}`}
         style={{willChange: 'background-color, filter, box-shadow'}}
@@ -568,6 +572,8 @@ export default function HeaderClient({
       <SearchModal 
         isOpen={isSearchOpen} 
         onClose={() => setIsSearchOpen(false)} 
+        vehicles={timberlineVehicles as any}
+        brands={brands as any}
       />
     </header>
     </>

--- a/frontend/app/components/SearchModal.tsx
+++ b/frontend/app/components/SearchModal.tsx
@@ -1,25 +1,95 @@
 "use client"
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
+import Link from 'next/link'
 import { MagnifyingGlassIcon, XMarkIcon, ClockIcon, ChartBarIcon } from '@heroicons/react/24/outline'
 
 interface SearchModalProps {
   isOpen: boolean
   onClose: () => void
+  vehicles?: Array<{
+    _id: string
+    title?: string
+    slug?: { current: string }
+    model?: string
+    vehicleType?: string
+    modelYear?: number
+    trim?: string
+    coverImage?: { asset?: { url?: string } }
+    manufacturer?: { name?: string }
+    tags?: string[]
+  }>
+  brands?: Array<{
+    _id: string
+    name: string
+    slug: { current: string }
+    logo?: { asset?: { url?: string } } | any
+  }>
 }
 
-export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
+export default function SearchModal({ isOpen, onClose, vehicles = [], brands = [] }: SearchModalProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [recentSearches, setRecentSearches] = useState<string[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [debouncedQuery, setDebouncedQuery] = useState('')
 
-  // Popular searches based on the design
+  // Debounce query to reduce re-computation
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 150)
+    return () => clearTimeout(id)
+  }, [searchQuery])
+
+  const results = useMemo(() => {
+    const q = debouncedQuery.toLowerCase()
+    if (!q) return { vehicles: [], brands: [] }
+
+    // Score helper: prioritize startsWith, then includes; more recent modelYear; then title length
+    const scoreText = (text: string) => {
+      const t = text.toLowerCase()
+      if (t.startsWith(q)) return 2
+      if (t.includes(q)) return 1
+      return 0
+    }
+
+    const vehicleMatches = (vehicles || [])
+      .map((v) => {
+        const title = v.title || ''
+        const model = v.model || ''
+        const manufacturer = v.manufacturer?.name || ''
+        const tags = Array.isArray(v.tags) ? v.tags.join(' ') : ''
+        const combined = `${title} ${model} ${manufacturer} ${tags}`
+        const s = scoreText(title) * 3 + scoreText(model) * 2 + scoreText(manufacturer) + scoreText(tags)
+        return { v, s, combined }
+      })
+      .filter(({ combined }) => combined.toLowerCase().includes(q))
+      .sort((a, b) => {
+        if (b.s !== a.s) return b.s - a.s
+        const yearA = a.v.modelYear || 0
+        const yearB = b.v.modelYear || 0
+        if (yearB !== yearA) return yearB - yearA
+        return (a.v.title || '').localeCompare(b.v.title || '')
+      })
+      .slice(0, 6)
+      .map(({ v }) => v)
+
+    const brandMatches = (brands || [])
+      .map((b) => ({ b, s: scoreText(b.name) }))
+      .filter(({ b }) => b.name.toLowerCase().includes(q))
+      .sort((a, b) => b.s - a.s || a.b.name.localeCompare(b.b.name))
+      .slice(0, 4)
+      .map(({ b }) => b)
+
+    return { vehicles: vehicleMatches, brands: brandMatches }
+  }, [debouncedQuery, vehicles, brands])
+
+  // Popular searches aligned with Timberline site
   const popularSearches = [
+    'TIMBERLINE',
     'TSPORT',
-    'TACTICAL VEHICLES', 
-    'F-150',
-    'RANGER',
-    'EVENTS'
+    'ALPINE',
+    'VEHICLES',
+    'BRANDS'
   ]
 
   // Load recent searches from localStorage
@@ -41,26 +111,42 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
     }
   }, [isOpen])
 
+  // Close when clicking outside the modal content
+  useEffect(() => {
+    if (!isOpen) return
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (contentRef.current && !contentRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => document.removeEventListener('mousedown', handleOutsideClick)
+  }, [isOpen, onClose])
+
   // Handle search
   const handleSearch = (query: string) => {
     if (query.trim()) {
       // Add to recent searches
-      const newRecent = [query.trim().toUpperCase(), ...recentSearches.filter(s => s !== query.trim().toUpperCase())].slice(0, 3)
+      const candidate = query.trim().toUpperCase()
+      const newRecent = [candidate, ...recentSearches.filter(s => s !== candidate)].slice(0, 3)
       setRecentSearches(newRecent)
       localStorage.setItem('timberline-recent-searches', JSON.stringify(newRecent))
       
       // TODO: Implement actual search functionality
       console.log('Searching for:', query)
-      
-      // Close modal
-      onClose()
     }
   }
 
   // Handle key press
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      handleSearch(searchQuery)
+      // Do not close on Enter; only record if there are results
+      if (searchQuery.trim()) {
+        // Optionally only record when there is at least one result
+        // const hasResults = results.vehicles.length > 0 || results.brands.length > 0
+        // if (hasResults) handleSearch(searchQuery)
+        handleSearch(searchQuery)
+      }
     } else if (e.key === 'Escape') {
       onClose()
     }
@@ -76,6 +162,16 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
 
   return (
     <>
+      <style jsx>{`
+        @keyframes softOrangeGlow {
+          0% { box-shadow: 0 0 0 0 rgba(255, 140, 66, 0.18); }
+          50% { box-shadow: 0 0 0 8px rgba(255, 140, 66, 0.06); }
+          100% { box-shadow: 0 0 0 0 rgba(255, 140, 66, 0.18); }
+        }
+        .orangePulse {
+          animation: softOrangeGlow 3.2s ease-in-out infinite;
+        }
+      `}</style>
       {/* Backdrop */}
       <div 
         className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
@@ -83,8 +179,8 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
       />
       
       {/* Modal */}
-      <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 px-4">
-        <div className="w-full max-w-4xl bg-black/90 backdrop-blur-xl border border-white/20 rounded-2xl shadow-2xl">
+      <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 px-4" onClick={onClose}>
+        <div ref={contentRef} className="w-full max-w-4xl bg-black/90 backdrop-blur-xl border border-white/20 rounded-2xl shadow-2xl" onClick={(e) => e.stopPropagation()}>
           {/* Search Bar */}
           <div className="p-6 border-b border-white/10">
             <div className="relative">
@@ -97,53 +193,134 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 onKeyPress={handleKeyPress}
-                placeholder="SEARCH TACTICAL VEHICLES, GEAR, EVENTS..."
-                className="w-full pl-14 pr-14 py-4 bg-white/5 border border-white/20 rounded-xl text-white placeholder-white/40 text-lg font-semibold uppercase tracking-wide focus:outline-none focus:border-[#ff8c42] focus:bg-white/10 transition-all duration-200"
+                placeholder="Search"
+                className={`w-full pl-14 pr-14 py-4 bg-white/5 border border-white/20 rounded-xl text-white placeholder-white/40 text-lg font-semibold uppercase tracking-wide focus:outline-none focus:border-[#ff8c42] focus:bg-white/10 transition-all duration-200 ${
+                  searchQuery.trim().length === 0 ? 'orangePulse' : ''
+                }`}
               />
               <button
-                onClick={() => setSearchQuery('')}
-                className="absolute right-4 top-1/2 transform -translate-y-1/2 w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-colors duration-200"
+                onClick={() => {
+                  if (searchQuery.trim().length === 0) {
+                    onClose()
+                  } else {
+                    setSearchQuery('')
+                  }
+                }}
+                className={`absolute right-4 top-1/2 transform -translate-y-1/2 w-8 h-8 rounded-full flex items-center justify-center transition-colors duration-200 ${
+                  searchQuery.trim().length === 0
+                    ? 'bg-white/10 hover:bg-red-500/20'
+                    : 'bg-white/10 hover:bg-orange-500/20'
+                }`}
+                aria-label={searchQuery.trim().length === 0 ? 'Close search' : 'Clear search'}
               >
-                <XMarkIcon className="w-4 h-4 text-white/60" />
+                <XMarkIcon className={`w-4 h-4 ${
+                  searchQuery.trim().length === 0 ? 'text-red-500' : 'text-orange-400'
+                }`} />
               </button>
             </div>
           </div>
 
           {/* Search Content */}
           <div className="p-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              {/* Popular Searches */}
-              <div>
-                <div className="flex items-center gap-2 mb-4">
-                  <ChartBarIcon className="w-5 h-5 text-[#ff8c42]" />
-                  <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">
-                    POPULAR SEARCHES
-                  </h3>
-                </div>
+            {debouncedQuery ? (
+              <div className="space-y-6">
+                {/* Vehicle Results */}
+                {results.vehicles.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-2 mb-3">
+                      <ChartBarIcon className="w-5 h-5 text-[#ff8c42]" />
+                      <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">Vehicles</h3>
+                    </div>
+                    <div className="space-y-2">
+                      {results.vehicles.map((v) => {
+                        const href = `/vehicles/${v.slug?.current}`
+                        const thumb = v.coverImage?.asset?.url
+                        return (
+                          <Link
+                            key={v._id}
+                            href={href}
+                            onClick={onClose}
+                            className="flex items-center gap-3 px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/20 hover:border-[#ff8c42]/50 transition-all duration-200"
+                          >
+                            {thumb ? (
+                              <img src={thumb} alt={v.title || ''} className="w-14 h-10 object-cover rounded-md border border-white/10" />
+                            ) : (
+                              <div className="w-14 h-10 rounded-md bg-white/5 border border-white/10" />
+                            )}
+                            <div className="min-w-0">
+                              <div className="text-white font-semibold truncate">
+                                {v.title}
+                              </div>
+                              <div className="text-white/60 text-xs uppercase tracking-wide truncate">
+                                {(v.modelYear ? `${v.modelYear} ` : '') + (v.model || '')} {v.manufacturer?.name ? `• ${v.manufacturer.name}` : ''}
+                              </div>
+                            </div>
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Brand Results */}
+                {results.brands.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-2 mb-3">
+                      <ClockIcon className="w-5 h-5 text-[#ff8c42]" />
+                      <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">Brands</h3>
+                    </div>
+                    <div className="space-y-2">
+                      {results.brands.map((b) => {
+                        const href = `/brands/${b.slug?.current}`
+                        // If logo has direct url field
+                        const logoUrl = (b as any).logo?.asset?.url || (b as any).logo?.url
+                        return (
+                          <Link
+                            key={b._id}
+                            href={href}
+                            onClick={onClose}
+                            className="flex items-center gap-3 px-3 py-2 rounded-xl bg-white/5 hover:bg-white/10 border border-white/20 hover:border-[#ff8c42]/50 transition-all duration-200"
+                          >
+                            {logoUrl ? (
+                              <img src={logoUrl} alt={b.name} className="w-10 h-10 object-contain rounded-md border border-white/10 bg-white/5" />
+                            ) : (
+                              <div className="w-10 h-10 rounded-md bg-white/5 border border-white/10" />
+                            )}
+                            <div className="min-w-0">
+                              <div className="text-white font-semibold truncate">
+                                {b.name}
+                              </div>
+                              <div className="text-white/60 text-xs uppercase tracking-wide truncate">Brand</div>
+                            </div>
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {results.vehicles.length === 0 && results.brands.length === 0 && (
+                  <div className="px-4 py-4">
+                    <div className="space-y-3">
+                      <div className="h-4 rounded bg-white/10 animate-pulse w-3/4" />
+                      <div className="h-4 rounded bg-white/10 animate-pulse w-5/6" />
+                      <div className="h-4 rounded bg-white/10 animate-pulse w-2/3" />
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {/* Popular Searches */}
+                <div>
+                  <div className="flex items-center gap-2 mb-4">
+                    <ChartBarIcon className="w-5 h-5 text-[#ff8c42]" />
+                    <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">
+                      POPULAR SEARCHES
+                    </h3>
+                  </div>
                 <div className="space-y-2">
                   {popularSearches.map((search, index) => (
-                    <button
-                      key={index}
-                      onClick={() => handleSearchClick(search)}
-                      className="w-full text-left px-4 py-3 bg-white/5 hover:bg-white/10 border border-white/20 hover:border-[#ff8c42]/50 rounded-xl text-white font-semibold uppercase tracking-wide transition-all duration-200 hover:scale-[1.02]"
-                    >
-                      {search}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Recent Searches */}
-              <div>
-                <div className="flex items-center gap-2 mb-4">
-                  <ClockIcon className="w-5 h-5 text-[#ff8c42]" />
-                  <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">
-                    RECENT SEARCHES
-                  </h3>
-                </div>
-                <div className="space-y-2">
-                  {recentSearches.length > 0 ? (
-                    recentSearches.map((search, index) => (
                       <button
                         key={index}
                         onClick={() => handleSearchClick(search)}
@@ -151,15 +328,38 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
                       >
                         {search}
                       </button>
-                    ))
-                  ) : (
-                    <div className="px-4 py-3 text-white/40 text-sm uppercase tracking-wide">
-                      No recent searches
-                    </div>
-                  )}
+                  ))}
+                  </div>
+                </div>
+
+                {/* Recent Searches */}
+                <div>
+                  <div className="flex items-center gap-2 mb-4">
+                    <ClockIcon className="w-5 h-5 text-[#ff8c42]" />
+                    <h3 className="text-[#ff8c42] text-lg font-bold uppercase tracking-wide">
+                      RECENT SEARCHES
+                    </h3>
+                  </div>
+                  <div className="space-y-2">
+                    {recentSearches.length > 0 ? (
+                      recentSearches.map((search, index) => (
+                        <button
+                          key={index}
+                          onClick={() => handleSearchClick(search)}
+                          className="w-full text-left px-4 py-3 bg-white/5 hover:bg-white/10 border border-white/20 hover:border-[#ff8c42]/50 rounded-xl text-white font-semibold uppercase tracking-wide transition-all duration-200 hover:scale-[1.02]"
+                        >
+                          {search}
+                        </button>
+                      ))
+                    ) : (
+                      <div className="px-4 py-3 text-white/40 text-sm uppercase tracking-wide">
+                        No recent searches
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Close Button */}

--- a/frontend/sanity.types.ts
+++ b/frontend/sanity.types.ts
@@ -14,798 +14,468 @@
 
 // Source: schema.json
 export type CallToAction = {
-  _type: 'callToAction'
-  heading: string
-  text?: string
-  buttonText?: string
-  link?: Link
-}
+  _type: "callToAction";
+  heading: string;
+  text?: string;
+  buttonText?: string;
+  link?: Link;
+};
 
 export type Link = {
-  _type: 'link'
-  linkType?: 'href' | 'page' | 'brand'
-  href?: string
+  _type: "link";
+  linkType?: "href" | "page" | "brand";
+  href?: string;
   page?: {
-    _ref: string
-    _type: 'reference'
-    _weak?: boolean
-    [internalGroqTypeReferenceTo]?: 'page'
-  }
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "page";
+  };
   brand?: {
-    _ref: string
-    _type: 'reference'
-    _weak?: boolean
-    [internalGroqTypeReferenceTo]?: 'brand'
-  }
-  openInNewTab?: boolean
-}
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "brand";
+  };
+  openInNewTab?: boolean;
+};
 
 export type InfoSection = {
-  _type: 'infoSection'
-  heading?: string
-  subheading?: string
+  _type: "infoSection";
+  heading?: string;
+  subheading?: string;
   content?: Array<{
     children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
-    listItem?: 'bullet' | 'number'
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+    listItem?: "bullet" | "number";
     markDefs?: Array<{
-      linkType?: 'href' | 'page' | 'brand'
-      href?: string
+      linkType?: "href" | "page" | "brand";
+      href?: string;
       page?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'page'
-      }
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "page";
+      };
       brand?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'brand'
-      }
-      openInNewTab?: boolean
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-}
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "brand";
+      };
+      openInNewTab?: boolean;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+};
 
 export type BlockContent = Array<{
   children?: Array<{
-    marks?: Array<string>
-    text?: string
-    _type: 'span'
-    _key: string
-  }>
-  style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
-  listItem?: 'bullet' | 'number'
+    marks?: Array<string>;
+    text?: string;
+    _type: "span";
+    _key: string;
+  }>;
+  style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+  listItem?: "bullet" | "number";
   markDefs?: Array<{
-    linkType?: 'href' | 'page' | 'brand'
-    href?: string
+    linkType?: "href" | "page" | "brand";
+    href?: string;
     page?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'page'
-    }
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "page";
+    };
     brand?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'brand'
-    }
-    openInNewTab?: boolean
-    _type: 'link'
-    _key: string
-  }>
-  level?: number
-  _type: 'block'
-  _key: string
-}>
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "brand";
+    };
+    openInNewTab?: boolean;
+    _type: "link";
+    _key: string;
+  }>;
+  level?: number;
+  _type: "block";
+  _key: string;
+}>;
 
 export type Settings = {
-  _id: string
-  _type: 'settings'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title: string
+  _id: string;
+  _type: "settings";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title: string;
   description?: Array<{
     children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'normal'
-    listItem?: never
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal";
+    listItem?: never;
     markDefs?: Array<{
-      linkType?: 'href' | 'page' | 'brand'
-      href?: string
+      linkType?: "href" | "page" | "brand";
+      href?: string;
       page?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'page'
-      }
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "page";
+      };
       brand?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'brand'
-      }
-      openInNewTab?: boolean
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "brand";
+      };
+      openInNewTab?: boolean;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
   ogImage?: {
     asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    metadataBase?: string
-    _type: 'image'
-  }
-}
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    metadataBase?: string;
+    _type: "image";
+  };
+};
 
 export type Page = {
-  _id: string
-  _type: 'page'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  name: string
-  slug: Slug
-  heading: string
-  subheading?: string
-  pageBuilder?: Array<
-    | ({
-        _key: string
-      } & CallToAction)
-    | ({
-        _key: string
-      } & InfoSection)
-  >
-}
+  _id: string;
+  _type: "page";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name: string;
+  slug: Slug;
+  heading: string;
+  subheading?: string;
+  pageBuilder?: Array<{
+    _key: string;
+  } & CallToAction | {
+    _key: string;
+  } & InfoSection>;
+};
 
 export type Brand = {
-  _id: string
-  _type: 'brand'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title: string
-  slug: Slug
-  content?: BlockContent
-  excerpt?: string
+  _id: string;
+  _type: "brand";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title: string;
+  slug: Slug;
+  content?: BlockContent;
+  excerpt?: string;
   coverImage: {
     asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-  date?: string
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "image";
+  };
+  date?: string;
   author?: {
-    _ref: string
-    _type: 'reference'
-    _weak?: boolean
-    [internalGroqTypeReferenceTo]?: 'person'
-  }
-}
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "person";
+  };
+};
 
 export type Person = {
-  _id: string
-  _type: 'person'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  firstName: string
-  lastName: string
+  _id: string;
+  _type: "person";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  firstName: string;
+  lastName: string;
   picture: {
     asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-}
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "image";
+  };
+};
 
 export type SanityAssistInstructionTask = {
-  _type: 'sanity.assist.instructionTask'
-  path?: string
-  instructionKey?: string
-  started?: string
-  updated?: string
-  info?: string
-}
+  _type: "sanity.assist.instructionTask";
+  path?: string;
+  instructionKey?: string;
+  started?: string;
+  updated?: string;
+  info?: string;
+};
 
 export type SanityAssistTaskStatus = {
-  _type: 'sanity.assist.task.status'
-  tasks?: Array<
-    {
-      _key: string
-    } & SanityAssistInstructionTask
-  >
-}
+  _type: "sanity.assist.task.status";
+  tasks?: Array<{
+    _key: string;
+  } & SanityAssistInstructionTask>;
+};
 
 export type SanityAssistSchemaTypeAnnotations = {
-  _type: 'sanity.assist.schemaType.annotations'
-  title?: string
-  fields?: Array<
-    {
-      _key: string
-    } & SanityAssistSchemaTypeField
-  >
-}
+  _type: "sanity.assist.schemaType.annotations";
+  title?: string;
+  fields?: Array<{
+    _key: string;
+  } & SanityAssistSchemaTypeField>;
+};
 
 export type SanityAssistOutputType = {
-  _type: 'sanity.assist.output.type'
-  type?: string
-}
+  _type: "sanity.assist.output.type";
+  type?: string;
+};
 
 export type SanityAssistOutputField = {
-  _type: 'sanity.assist.output.field'
-  path?: string
-}
+  _type: "sanity.assist.output.field";
+  path?: string;
+};
 
 export type SanityAssistInstructionContext = {
-  _type: 'sanity.assist.instruction.context'
+  _type: "sanity.assist.instruction.context";
   reference: {
-    _ref: string
-    _type: 'reference'
-    _weak?: boolean
-    [internalGroqTypeReferenceTo]?: 'assist.instruction.context'
-  }
-}
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "assist.instruction.context";
+  };
+};
 
 export type AssistInstructionContext = {
-  _id: string
-  _type: 'assist.instruction.context'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
+  _id: string;
+  _type: "assist.instruction.context";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
   context?: Array<{
     children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'normal'
-    listItem?: never
-    markDefs?: null
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-}
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal";
+    listItem?: never;
+    markDefs?: null;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+};
 
 export type SanityAssistInstructionUserInput = {
-  _type: 'sanity.assist.instruction.userInput'
-  message: string
-  description?: string
-}
+  _type: "sanity.assist.instruction.userInput";
+  message: string;
+  description?: string;
+};
 
 export type SanityAssistInstructionPrompt = Array<{
-  children?: Array<
-    | {
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }
-    | ({
-        _key: string
-      } & SanityAssistInstructionFieldRef)
-    | ({
-        _key: string
-      } & SanityAssistInstructionContext)
-    | ({
-        _key: string
-      } & SanityAssistInstructionUserInput)
-  >
-  style?: 'normal'
-  listItem?: never
-  markDefs?: null
-  level?: number
-  _type: 'block'
-  _key: string
-}>
+  children?: Array<{
+    marks?: Array<string>;
+    text?: string;
+    _type: "span";
+    _key: string;
+  } | {
+    _key: string;
+  } & SanityAssistInstructionFieldRef | {
+    _key: string;
+  } & SanityAssistInstructionContext | {
+    _key: string;
+  } & SanityAssistInstructionUserInput>;
+  style?: "normal";
+  listItem?: never;
+  markDefs?: null;
+  level?: number;
+  _type: "block";
+  _key: string;
+}>;
 
 export type SanityAssistInstructionFieldRef = {
-  _type: 'sanity.assist.instruction.fieldRef'
-  path?: string
-}
+  _type: "sanity.assist.instruction.fieldRef";
+  path?: string;
+};
 
 export type SanityAssistInstruction = {
-  _type: 'sanity.assist.instruction'
-  prompt?: SanityAssistInstructionPrompt
-  icon?: string
-  title?: string
-  userId?: string
-  createdById?: string
-  output?: Array<
-    | ({
-        _key: string
-      } & SanityAssistOutputField)
-    | ({
-        _key: string
-      } & SanityAssistOutputType)
-  >
-}
+  _type: "sanity.assist.instruction";
+  prompt?: SanityAssistInstructionPrompt;
+  icon?: string;
+  title?: string;
+  userId?: string;
+  createdById?: string;
+  output?: Array<{
+    _key: string;
+  } & SanityAssistOutputField | {
+    _key: string;
+  } & SanityAssistOutputType>;
+};
 
 export type SanityAssistSchemaTypeField = {
-  _type: 'sanity.assist.schemaType.field'
-  path?: string
-  instructions?: Array<
-    {
-      _key: string
-    } & SanityAssistInstruction
-  >
-}
+  _type: "sanity.assist.schemaType.field";
+  path?: string;
+  instructions?: Array<{
+    _key: string;
+  } & SanityAssistInstruction>;
+};
 
 export type SanityImagePaletteSwatch = {
-  _type: 'sanity.imagePaletteSwatch'
-  background?: string
-  foreground?: string
-  population?: number
-  title?: string
-}
+  _type: "sanity.imagePaletteSwatch";
+  background?: string;
+  foreground?: string;
+  population?: number;
+  title?: string;
+};
 
 export type SanityImagePalette = {
-  _type: 'sanity.imagePalette'
-  darkMuted?: SanityImagePaletteSwatch
-  lightVibrant?: SanityImagePaletteSwatch
-  darkVibrant?: SanityImagePaletteSwatch
-  vibrant?: SanityImagePaletteSwatch
-  dominant?: SanityImagePaletteSwatch
-  lightMuted?: SanityImagePaletteSwatch
-  muted?: SanityImagePaletteSwatch
-}
+  _type: "sanity.imagePalette";
+  darkMuted?: SanityImagePaletteSwatch;
+  lightVibrant?: SanityImagePaletteSwatch;
+  darkVibrant?: SanityImagePaletteSwatch;
+  vibrant?: SanityImagePaletteSwatch;
+  dominant?: SanityImagePaletteSwatch;
+  lightMuted?: SanityImagePaletteSwatch;
+  muted?: SanityImagePaletteSwatch;
+};
 
 export type SanityImageDimensions = {
-  _type: 'sanity.imageDimensions'
-  height?: number
-  width?: number
-  aspectRatio?: number
-}
+  _type: "sanity.imageDimensions";
+  height?: number;
+  width?: number;
+  aspectRatio?: number;
+};
 
 export type SanityImageHotspot = {
-  _type: 'sanity.imageHotspot'
-  x?: number
-  y?: number
-  height?: number
-  width?: number
-}
+  _type: "sanity.imageHotspot";
+  x?: number;
+  y?: number;
+  height?: number;
+  width?: number;
+};
 
 export type SanityImageCrop = {
-  _type: 'sanity.imageCrop'
-  top?: number
-  bottom?: number
-  left?: number
-  right?: number
-}
+  _type: "sanity.imageCrop";
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+};
 
 export type SanityFileAsset = {
-  _id: string
-  _type: 'sanity.fileAsset'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  originalFilename?: string
-  label?: string
-  title?: string
-  description?: string
-  altText?: string
-  sha1hash?: string
-  extension?: string
-  mimeType?: string
-  size?: number
-  assetId?: string
-  uploadId?: string
-  path?: string
-  url?: string
-  source?: SanityAssetSourceData
-}
+  _id: string;
+  _type: "sanity.fileAsset";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  originalFilename?: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  altText?: string;
+  sha1hash?: string;
+  extension?: string;
+  mimeType?: string;
+  size?: number;
+  assetId?: string;
+  uploadId?: string;
+  path?: string;
+  url?: string;
+  source?: SanityAssetSourceData;
+};
 
 export type SanityImageAsset = {
-  _id: string
-  _type: 'sanity.imageAsset'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  originalFilename?: string
-  label?: string
-  title?: string
-  description?: string
-  altText?: string
-  sha1hash?: string
-  extension?: string
-  mimeType?: string
-  size?: number
-  assetId?: string
-  uploadId?: string
-  path?: string
-  url?: string
-  metadata?: SanityImageMetadata
-  source?: SanityAssetSourceData
-}
+  _id: string;
+  _type: "sanity.imageAsset";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  originalFilename?: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  altText?: string;
+  sha1hash?: string;
+  extension?: string;
+  mimeType?: string;
+  size?: number;
+  assetId?: string;
+  uploadId?: string;
+  path?: string;
+  url?: string;
+  metadata?: SanityImageMetadata;
+  source?: SanityAssetSourceData;
+};
 
 export type SanityImageMetadata = {
-  _type: 'sanity.imageMetadata'
-  location?: Geopoint
-  dimensions?: SanityImageDimensions
-  palette?: SanityImagePalette
-  lqip?: string
-  blurHash?: string
-  hasAlpha?: boolean
-  isOpaque?: boolean
-}
+  _type: "sanity.imageMetadata";
+  location?: Geopoint;
+  dimensions?: SanityImageDimensions;
+  palette?: SanityImagePalette;
+  lqip?: string;
+  blurHash?: string;
+  hasAlpha?: boolean;
+  isOpaque?: boolean;
+};
 
 export type Geopoint = {
-  _type: 'geopoint'
-  lat?: number
-  lng?: number
-  alt?: number
-}
+  _type: "geopoint";
+  lat?: number;
+  lng?: number;
+  alt?: number;
+};
 
 export type Slug = {
-  _type: 'slug'
-  current: string
-  source?: string
-}
+  _type: "slug";
+  current: string;
+  source?: string;
+};
 
 export type SanityAssetSourceData = {
-  _type: 'sanity.assetSourceData'
-  name?: string
-  id?: string
-  url?: string
-}
+  _type: "sanity.assetSourceData";
+  name?: string;
+  id?: string;
+  url?: string;
+};
 
-export type AllSanitySchemaTypes =
-  | CallToAction
-  | Link
-  | InfoSection
-  | BlockContent
-  | Settings
-  | Page
-  | Brand
-  | Person
-  | SanityAssistInstructionTask
-  | SanityAssistTaskStatus
-  | SanityAssistSchemaTypeAnnotations
-  | SanityAssistOutputType
-  | SanityAssistOutputField
-  | SanityAssistInstructionContext
-  | AssistInstructionContext
-  | SanityAssistInstructionUserInput
-  | SanityAssistInstructionPrompt
-  | SanityAssistInstructionFieldRef
-  | SanityAssistInstruction
-  | SanityAssistSchemaTypeField
-  | SanityImagePaletteSwatch
-  | SanityImagePalette
-  | SanityImageDimensions
-  | SanityImageHotspot
-  | SanityImageCrop
-  | SanityFileAsset
-  | SanityImageAsset
-  | SanityImageMetadata
-  | Geopoint
-  | Slug
-  | SanityAssetSourceData
-export declare const internalGroqTypeReferenceTo: unique symbol
-// Source: ./sanity/lib/queries.ts
-// Variable: settingsQuery
-// Query: *[_type == "settings"][0]{  ...,  appLogo}
-export type SettingsQueryResult = {
-  _id: string
-  _type: 'settings'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title: string
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'normal'
-    listItem?: never
-    markDefs?: Array<{
-      linkType?: 'brand' | 'href' | 'page'
-      href?: string
-      page?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'page'
-      }
-      brand?: {
-        _ref: string
-        _type: 'reference'
-        _weak?: boolean
-        [internalGroqTypeReferenceTo]?: 'brand'
-      }
-      openInNewTab?: boolean
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  ogImage?: {
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    metadataBase?: string
-    _type: 'image'
-  }
-  appLogo: null
-} | null
-// Variable: homepageSettingsQuery
-// Query: *[_type == "homepageSettings"][0]{  heroSlides[]{    title,    subtitle,    image,  }}
-export type HomepageSettingsQueryResult = null
-// Variable: getPageQuery
-// Query: *[_type == 'page' && slug.current == $slug][0]{    _id,    _type,    name,    slug,    heading,    subheading,    "pageBuilder": pageBuilder[]{      ...,      _type == "callToAction" => {          link {      ...,        _type == "link" => {    "page": page->slug.current,    "brand": brand->slug.current  }      },      },      _type == "infoSection" => {        content[]{          ...,          markDefs[]{            ...,              _type == "link" => {    "page": page->slug.current,    "brand": brand->slug.current  }          }        }      },    },  }
-export type GetPageQueryResult = {
-  _id: string
-  _type: 'page'
-  name: string
-  slug: Slug
-  heading: string
-  subheading: string | null
-  pageBuilder: Array<
-    | {
-        _key: string
-        _type: 'callToAction'
-        heading: string
-        text?: string
-        buttonText?: string
-        link: {
-          _type: 'link'
-          linkType?: 'brand' | 'href' | 'page'
-          href?: string
-          page: string | null
-          brand: string | null
-          openInNewTab?: boolean
-        } | null
-      }
-    | {
-        _key: string
-        _type: 'infoSection'
-        heading?: string
-        subheading?: string
-        content: Array<{
-          children?: Array<{
-            marks?: Array<string>
-            text?: string
-            _type: 'span'
-            _key: string
-          }>
-          style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-          listItem?: 'bullet' | 'number'
-          markDefs: Array<{
-            linkType?: 'brand' | 'href' | 'page'
-            href?: string
-            page: string | null
-            brand: string | null
-            openInNewTab?: boolean
-            _type: 'link'
-            _key: string
-          }> | null
-          level?: number
-          _type: 'block'
-          _key: string
-        }> | null
-      }
-  > | null
-} | null
-// Variable: sitemapData
-// Query: *[_type == "page" || _type == "brand" && defined(slug.current)] | order(_type asc) {    "slug": slug.current,    _type,    _updatedAt,  }
-export type SitemapDataResult = Array<
-  | {
-      slug: string
-      _type: 'brand'
-      _updatedAt: string
-    }
-  | {
-      slug: string
-      _type: 'page'
-      _updatedAt: string
-    }
->
-// Variable: allBrandsQuery
-// Query: *[_type == "brand" && defined(slug.current)] | order(launchDate desc, _updatedAt desc) {      _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "name": coalesce(name, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  features,  "launchDate": coalesce(launchDate, _updatedAt),  }
-export type AllBrandsQueryResult = Array<{
-  _id: string
-  status: 'draft' | 'published'
-  name: 'Untitled'
-  slug: string
-  excerpt: string | null
-  coverImage: {
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-  features: null
-  launchDate: string
-}>
-// Variable: moreBrandsQuery
-// Query: *[_type == "brand" && _id != $skip && defined(slug.current)] | order(launchDate desc, _updatedAt desc) [0...$limit] {      _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "name": coalesce(name, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  features,  "launchDate": coalesce(launchDate, _updatedAt),  }
-export type MoreBrandsQueryResult = Array<{
-  _id: string
-  status: 'draft' | 'published'
-  name: 'Untitled'
-  slug: string
-  excerpt: string | null
-  coverImage: {
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-  features: null
-  launchDate: string
-}>
-// Variable: homepageBrandsQuery
-// Query: *[_type == "brand" && defined(slug.current)] | order(name asc) {      _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "name": coalesce(name, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  features,  "launchDate": coalesce(launchDate, _updatedAt),  }
-export type HomepageBrandsQueryResult = Array<{
-  _id: string
-  status: 'draft' | 'published'
-  name: 'Untitled'
-  slug: string
-  excerpt: string | null
-  coverImage: {
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-  features: null
-  launchDate: string
-}>
-// Variable: brandQuery
-// Query: *[_type == "brand" && slug.current == $slug] [0] {    description[]{    ...,    markDefs[]{      ...,        _type == "link" => {    "page": page->slug.current,    "brand": brand->slug.current  }    }  },      _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "name": coalesce(name, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  features,  "launchDate": coalesce(launchDate, _updatedAt),  }
-export type BrandQueryResult = {
-  description: null
-  _id: string
-  status: 'draft' | 'published'
-  name: 'Untitled'
-  slug: string
-  excerpt: string | null
-  coverImage: {
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-  }
-  features: null
-  launchDate: string
-} | null
-// Variable: brandPagesSlugs
-// Query: *[_type == "brand" && defined(slug.current)]  {"slug": slug.current}
-export type BrandPagesSlugsResult = Array<{
-  slug: string
-}>
-// Variable: pagesSlugs
-// Query: *[_type == "page" && defined(slug.current)]  {"slug": slug.current}
-export type PagesSlugsResult = Array<{
-  slug: string
-}>
-// Variable: manufacturerQuery
-// Query: *[_type == "manufacturer" && slug.current == $slug][0] {    _id,    name,    slug,    logo,    description,        // Hero Section    heroImage {      asset-> {        url      }    },    heroTitle,    heroSubtitle,    heroCtaText,        // Showcase Images    showcaseImages[] {      model,      image {        asset-> {          url        }      },      altText    },        // Gallery Images    galleryImages[] {      image {        asset-> {          url        }      },      caption,      category,      altText    },        // CTA Section    ctaTitle,    ctaDescription,    ctaStats[] {      value,      label    },    additionalLinks[] {      text,      url    },        // SEO    seoTitle,    seoDescription,    seoImage {      asset-> {        url      }    },        "vehicles": *[_type == "vehicle" && references(^._id)] {      _id,      title,      slug,      model,      vehicleType,      modelYear,      upfitter,      package,      "manufacturer": manufacturer->name    } | order(model asc, upfitter asc, package asc)  }
-export type ManufacturerQueryResult = null
-// Variable: manufacturerSlugs
-// Query: *[_type == "manufacturer" && defined(slug.current)]  {"slug": slug.current}
-export type ManufacturerSlugsResult = Array<never>
-// Variable: allManufacturersQuery
-// Query: *[_type == "manufacturer" && defined(slug.current)] | order(name asc) {    _id,    name,    slug,    logo,    "vehicleCount": count(*[_type == "vehicle" && references(^._id)])  }
-export type AllManufacturersQueryResult = Array<never>
-// Variable: allVehiclesQuery
-// Query: *[_type == "vehicle" && defined(slug.current)] | order(modelYear desc, title asc) {    _id,    title,    slug,    model,    vehicleType,    modelYear,    trim,    "manufacturer": manufacturer->{      _id,      name,      logo    },    coverImage,    specifications,    features,    inventory,    tags  }
-export type AllVehiclesQueryResult = Array<never>
-// Variable: timberlineVehiclesQuery
-// Query: *[_type == "vehicle" && defined(slug.current) && "Timberline" in tags] | order(modelYear desc, title asc) {    _id,    title,    slug,    model,    vehicleType,    modelYear,    trim,    "manufacturer": manufacturer->{      _id,      name,      logo    },    coverImage,    specifications,    features,    inventory,    tags  }
-export type TimberlineVehiclesQueryResult = Array<never>
-// Variable: vehicleQuery
-// Query: *[_type == "vehicle" && slug.current == $slug][0] {    _id,    title,    slug,    model,    vehicleType,    modelYear,    trim,    "manufacturer": manufacturer->{      _id,      name,      logo    },    coverImage,    gallery,    videoTour,    specifications,    features,    customizationOptions,    inventory,    description,    tags,    seo  }
-export type VehicleQueryResult = null
-// Variable: vehicleSlugs
-// Query: *[_type == "vehicle" && defined(slug.current)]  {"slug": slug.current}
-export type VehicleSlugsResult = Array<never>
-
-// Query TypeMap
-import '@sanity/client'
-declare module '@sanity/client' {
-  interface SanityQueries {
-    '*[_type == "settings"][0]{\n  ...,\n  appLogo\n}': SettingsQueryResult
-    '*[_type == "homepageSettings"][0]{\n  heroSlides[]{\n    title,\n    subtitle,\n    image,\n  }\n}': HomepageSettingsQueryResult
-    '\n  *[_type == \'page\' && slug.current == $slug][0]{\n    _id,\n    _type,\n    name,\n    slug,\n    heading,\n    subheading,\n    "pageBuilder": pageBuilder[]{\n      ...,\n      _type == "callToAction" => {\n        \n  link {\n      ...,\n      \n  _type == "link" => {\n    "page": page->slug.current,\n    "brand": brand->slug.current\n  }\n\n      }\n,\n      },\n      _type == "infoSection" => {\n        content[]{\n          ...,\n          markDefs[]{\n            ...,\n            \n  _type == "link" => {\n    "page": page->slug.current,\n    "brand": brand->slug.current\n  }\n\n          }\n        }\n      },\n    },\n  }\n': GetPageQueryResult
-    '\n  *[_type == "page" || _type == "brand" && defined(slug.current)] | order(_type asc) {\n    "slug": slug.current,\n    _type,\n    _updatedAt,\n  }\n': SitemapDataResult
-    '\n  *[_type == "brand" && defined(slug.current)] | order(launchDate desc, _updatedAt desc) {\n    \n  _id,\n  "status": select(_originalId in path("drafts.**") => "draft", "published"),\n  "name": coalesce(name, "Untitled"),\n  "slug": slug.current,\n  excerpt,\n  coverImage,\n  features,\n  "launchDate": coalesce(launchDate, _updatedAt),\n\n  }\n': AllBrandsQueryResult
-    '\n  *[_type == "brand" && _id != $skip && defined(slug.current)] | order(launchDate desc, _updatedAt desc) [0...$limit] {\n    \n  _id,\n  "status": select(_originalId in path("drafts.**") => "draft", "published"),\n  "name": coalesce(name, "Untitled"),\n  "slug": slug.current,\n  excerpt,\n  coverImage,\n  features,\n  "launchDate": coalesce(launchDate, _updatedAt),\n\n  }\n': MoreBrandsQueryResult
-    '\n  *[_type == "brand" && defined(slug.current)] | order(name asc) {\n    \n  _id,\n  "status": select(_originalId in path("drafts.**") => "draft", "published"),\n  "name": coalesce(name, "Untitled"),\n  "slug": slug.current,\n  excerpt,\n  coverImage,\n  features,\n  "launchDate": coalesce(launchDate, _updatedAt),\n\n  }\n': HomepageBrandsQueryResult
-    '\n  *[_type == "brand" && slug.current == $slug] [0] {\n    description[]{\n    ...,\n    markDefs[]{\n      ...,\n      \n  _type == "link" => {\n    "page": page->slug.current,\n    "brand": brand->slug.current\n  }\n\n    }\n  },\n    \n  _id,\n  "status": select(_originalId in path("drafts.**") => "draft", "published"),\n  "name": coalesce(name, "Untitled"),\n  "slug": slug.current,\n  excerpt,\n  coverImage,\n  features,\n  "launchDate": coalesce(launchDate, _updatedAt),\n\n  }\n': BrandQueryResult
-    '\n  *[_type == "brand" && defined(slug.current)]\n  {"slug": slug.current}\n': BrandPagesSlugsResult
-    '\n  *[_type == "page" && defined(slug.current)]\n  {"slug": slug.current}\n': PagesSlugsResult
-    '\n  *[_type == "manufacturer" && slug.current == $slug][0] {\n    _id,\n    name,\n    slug,\n    logo,\n    description,\n    \n    // Hero Section\n    heroImage {\n      asset-> {\n        url\n      }\n    },\n    heroTitle,\n    heroSubtitle,\n    heroCtaText,\n    \n    // Showcase Images\n    showcaseImages[] {\n      model,\n      image {\n        asset-> {\n          url\n        }\n      },\n      altText\n    },\n    \n    // Gallery Images\n    galleryImages[] {\n      image {\n        asset-> {\n          url\n        }\n      },\n      caption,\n      category,\n      altText\n    },\n    \n    // CTA Section\n    ctaTitle,\n    ctaDescription,\n    ctaStats[] {\n      value,\n      label\n    },\n    additionalLinks[] {\n      text,\n      url\n    },\n    \n    // SEO\n    seoTitle,\n    seoDescription,\n    seoImage {\n      asset-> {\n        url\n      }\n    },\n    \n    "vehicles": *[_type == "vehicle" && references(^._id)] {\n      _id,\n      title,\n      slug,\n      model,\n      vehicleType,\n      modelYear,\n      upfitter,\n      package,\n      "manufacturer": manufacturer->name\n    } | order(model asc, upfitter asc, package asc)\n  }\n': ManufacturerQueryResult
-    '\n  *[_type == "manufacturer" && defined(slug.current)]\n  {"slug": slug.current}\n': ManufacturerSlugsResult
-    '\n  *[_type == "manufacturer" && defined(slug.current)] | order(name asc) {\n    _id,\n    name,\n    slug,\n    logo,\n    "vehicleCount": count(*[_type == "vehicle" && references(^._id)])\n  }\n': AllManufacturersQueryResult
-    '\n  *[_type == "vehicle" && defined(slug.current)] | order(modelYear desc, title asc) {\n    _id,\n    title,\n    slug,\n    model,\n    vehicleType,\n    modelYear,\n    trim,\n    "manufacturer": manufacturer->{\n      _id,\n      name,\n      logo\n    },\n    coverImage,\n    specifications,\n    features,\n    inventory,\n    tags\n  }\n': AllVehiclesQueryResult
-    '\n  *[_type == "vehicle" && defined(slug.current) && "Timberline" in tags] | order(modelYear desc, title asc) {\n    _id,\n    title,\n    slug,\n    model,\n    vehicleType,\n    modelYear,\n    trim,\n    "manufacturer": manufacturer->{\n      _id,\n      name,\n      logo\n    },\n    coverImage,\n    specifications,\n    features,\n    inventory,\n    tags\n  }\n': TimberlineVehiclesQueryResult
-    '\n  *[_type == "vehicle" && slug.current == $slug][0] {\n    _id,\n    title,\n    slug,\n    model,\n    vehicleType,\n    modelYear,\n    trim,\n    "manufacturer": manufacturer->{\n      _id,\n      name,\n      logo\n    },\n    coverImage,\n    gallery,\n    videoTour,\n    specifications,\n    features,\n    customizationOptions,\n    inventory,\n    description,\n    tags,\n    seo\n  }\n': VehicleQueryResult
-    '\n  *[_type == "vehicle" && defined(slug.current)]\n  {"slug": slug.current}\n': VehicleSlugsResult
-  }
-}
+export type AllSanitySchemaTypes = CallToAction | Link | InfoSection | BlockContent | Settings | Page | Brand | Person | SanityAssistInstructionTask | SanityAssistTaskStatus | SanityAssistSchemaTypeAnnotations | SanityAssistOutputType | SanityAssistOutputField | SanityAssistInstructionContext | AssistInstructionContext | SanityAssistInstructionUserInput | SanityAssistInstructionPrompt | SanityAssistInstructionFieldRef | SanityAssistInstruction | SanityAssistSchemaTypeField | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageHotspot | SanityImageCrop | SanityFileAsset | SanityImageAsset | SanityImageMetadata | Geopoint | Slug | SanityAssetSourceData;
+export declare const internalGroqTypeReferenceTo: unique symbol;


### PR DESCRIPTION
Hide header orange borders when search is open
Outside-click to close modal
Live suggestions for vehicles and brands with images
Recent searches records actual submitted queries (de-duped, last 3)
Placeholder changed to “Search”; subtle orange glow when empty
X button: orange when text (clears), red when empty (closes)
Empty results show a 3-line animated skeleton
Verified Enter doesn’t close; Esc closes; suggestion click navigates and closes